### PR TITLE
revert dist build folders

### DIFF
--- a/.github/workflows/blui-ci.yml
+++ b/.github/workflows/blui-ci.yml
@@ -31,14 +31,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: angular/components
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: angular/demos/showcase
     - run: yarn prettier:check
       working-directory: angular/components
@@ -76,14 +76,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: react/icons
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: react/demo
     - run: yarn prettier:check
       working-directory: react/icons
@@ -121,14 +121,14 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: react-native
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
+    - run: yarn install --immutable
       working-directory: react-native/demo
     - run: yarn prettier:check
       working-directory: react-native
@@ -172,7 +172,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn --frozen-lockfile
+      - run: yarn --immutable
         working-directory: angular/components
       - run: npm run publish:package -b ${{env.BRANCH}}
         working-directory: angular/components
@@ -198,7 +198,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn --frozen-lockfile
+      - run: yarn --immutable
         working-directory: react/icons
       - run: npm run publish:package -b ${{env.BRANCH}}
         working-directory: react/icons
@@ -224,7 +224,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn --frozen-lockfile
+      - run: yarn --immutable
         working-directory: react-native
       - run: npm run publish:package -b ${{env.BRANCH}}
         working-directory: react-native

--- a/.github/workflows/blui-ci.yml
+++ b/.github/workflows/blui-ci.yml
@@ -1,4 +1,4 @@
-name: CI Run
+name: Build
 
 on:
   push:
@@ -31,7 +31,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: angular/components
     - run: yarn install --frozen-lockfile
       working-directory: angular/components
     - name: Use Node.js ${{ matrix.node-version }}
@@ -39,7 +38,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: angular/demos/showcase
     - run: yarn install --frozen-lockfile
       working-directory: angular/demos/showcase
     - run: yarn prettier:check
@@ -59,7 +57,7 @@ jobs:
     - name: Save angular progress icon build
       uses: actions/upload-artifact@v3
       with:
-        name: dist
+        name: angular-dist
         if-no-files-found: error
         path: angular/dist
 
@@ -78,7 +76,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: react/icons
     - run: yarn install --frozen-lockfile
       working-directory: react/icons
     - name: Use Node.js ${{ matrix.node-version }}
@@ -86,7 +83,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: react/demo
     - run: yarn install --frozen-lockfile
       working-directory: react/demo
     - run: yarn prettier:check
@@ -108,7 +104,7 @@ jobs:
       with:
         name: react-dist
         if-no-files-found: error
-        path: react/icons/react-dist
+        path: react/icons/dist
 
   rn_progress_icons:
     runs-on: ubuntu-latest
@@ -125,7 +121,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: react-native
     - run: yarn install --frozen-lockfile
       working-directory: react-native
     - name: Use Node.js ${{ matrix.node-version }}
@@ -133,7 +128,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-        cache-dependency-path: react-native/demo
     - run: yarn install --frozen-lockfile
       working-directory: react-native/demo
     - run: yarn prettier:check
@@ -155,7 +149,7 @@ jobs:
       with:
         name: rn-dist
         if-no-files-found: error
-        path: react-native/rn-dist
+        path: react-native/dist
 
   publish_angular_progress_icons:
     runs-on: ubuntu-latest
@@ -198,7 +192,7 @@ jobs:
       - name: Download react progress icons package
         uses: actions/download-artifact@v3
         with:
-          name: react-dist
+          name: dist
           path: react/icons
       - uses: actions/setup-node@v3
         with:
@@ -224,7 +218,7 @@ jobs:
       - name: Download react progress icons package
         uses: actions/download-artifact@v3
         with:
-          name: rn-dist
+          name: dist
           path: react-native
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/blui-ci.yml
+++ b/.github/workflows/blui-ci.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Download angular progress icons package
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: angular-dist
           path: angular/dist
       - uses: actions/setup-node@v3
         with:
@@ -192,7 +192,7 @@ jobs:
       - name: Download react progress icons package
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: react-dist
           path: react/icons/dist
       - uses: actions/setup-node@v3
         with:
@@ -218,7 +218,7 @@ jobs:
       - name: Download react progress icons package
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: rn-dist
           path: react-native/dist
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/blui-ci.yml
+++ b/.github/workflows/blui-ci.yml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: dist
-          path: react/icons
+          path: react/icons/dist
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
@@ -219,7 +219,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: dist
-          path: react-native
+          path: react-native/dist
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ build.bundle
 /build
 /tmp
 angular/dist
-react/icons/react-dist
-react-native/rn-dist
+react/icons/dist
+react-native/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://img.shields.io/npm/v/@brightlayer-ui/ng-progress-icons.svg?label=@brightlayer-ui/ng-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/ng-progress-icons)
 [![](https://img.shields.io/npm/v/@brightlayer-ui/react-progress-icons.svg?label=@brightlayer-ui/react-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-progress-icons)
-[![](https://img.shields.io/npm/v/@brightlayer-ui/react-native-progress-icons.svg?label=@brightlayer-ui/react-native-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-native-progress-icons)
+[![](https://img.shields.io/npm/v/@brightlayer-ui/react-native-progress-icons.svg?label=@brightlayer-ui/react-native-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-native-progress-icons)[![Build](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml/badge.svg)](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml)
 
 <img width="100%" style="max-width: 600px" alt="Progress icons" src="https://raw.githubusercontent.com/etn-ccis/blui-progress-icons/master/assets/progress-icons.png" />
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://img.shields.io/npm/v/@brightlayer-ui/ng-progress-icons.svg?label=@brightlayer-ui/ng-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/ng-progress-icons)
 [![](https://img.shields.io/npm/v/@brightlayer-ui/react-progress-icons.svg?label=@brightlayer-ui/react-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-progress-icons)
-[![](https://img.shields.io/npm/v/@brightlayer-ui/react-native-progress-icons.svg?label=@brightlayer-ui/react-native-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-native-progress-icons)[![Build](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml/badge.svg)](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml)
+[![](https://img.shields.io/npm/v/@brightlayer-ui/react-native-progress-icons.svg?label=@brightlayer-ui/react-native-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-native-progress-icons)[![Build](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml/badge.svg?branch=master)](https://github.com/etn-ccis/blui-progress-icons/actions/workflows/blui-ci.yml)
 
 <img width="100%" style="max-width: 600px" alt="Progress icons" src="https://raw.githubusercontent.com/etn-ccis/blui-progress-icons/master/assets/progress-icons.png" />
 

--- a/angular/components/PUBLISHING.md
+++ b/angular/components/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 ## Automatic Publishing
 
-This package is published to NPM automatically by CircleCI when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `package.json` and merge your code into the appropriate branch.
+This package is published to NPM automatically by Github when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `package.json` and merge your code into the appropriate branch.
 - The `dev` branch will publish versions marked as `alpha` or `beta`.
 - The `master` branch will publish any version (`alpha`, `beta`, or `latest`).
   In both cases, the code will only be published if the version number differs from the current version published under the respective dist tag.
@@ -25,4 +25,4 @@ yarn build
 npm adduser && yarn publish:package
 ```
 
-> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in CircleCI.
+> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in Github.

--- a/angular/components/package.json
+++ b/angular/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/ng-progress-icons",
-    "version": "2.0.0-beta.0",
+    "version": "2.0.0-beta.1",
     "description": "Angular progress icons for Brightlayer UI applications",
     "main": "bundles/brightlayer-ui-ng-progress-icons.umd.js",
     "scripts": {

--- a/react-native/PUBLISHING.md
+++ b/react-native/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 ## Automatic Publishing
 
-This package is published to NPM automatically by CircleCI when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `icons/package.json` and merge your code into the appropriate branch.
+This package is published to NPM automatically by Github when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `icons/package.json` and merge your code into the appropriate branch.
 
 -   The `dev` branch will publish versions marked as `alpha` or `beta`.
 -   The `master` branch will publish any version (`alpha`, `beta`, or `latest`).
@@ -26,4 +26,4 @@ yarn build
 npm adduser && yarn publish:package
 ```
 
-> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in CircleCI.
+> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in Github.

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -1,7 +1,6 @@
 # Brightlayer UI React Native Progress Icons
 
 [![](https://img.shields.io/npm/v/@brightlayer-ui/react-native-progress-icons.svg?label=@brightlayer-ui/react-native-progress-icons&style=flat)](https://www.npmjs.com/package/@brightlayer-ui/react-native-progress-icons)
-[![](https://img.shields.io/circleci/project/github/etn-ccis/blui-progress-icons/master.svg?style=flat)](https://circleci.com/gh/etn-ccis/blui-progress-icons/tree/master)
 
 <img width="100%" style="max-width: 600px" alt="Progress icons" src="https://raw.githubusercontent.com/etn-ccis/blui-progress-icons/master/assets/progress-icons.png" />
 

--- a/react-native/scripts/buildIcons.sh
+++ b/react-native/scripts/buildIcons.sh
@@ -11,13 +11,13 @@ GRAY='\033[1;30m'
 NC='\033[0m' # No Color
 
 # Remove previous build
-rm -rf ./rn-dist
+rm -rf ./dist
 yarn && tsc --p tsconfig.lib.json
 
 echo -e "${BLUE}Copying Package Resources${NC}"
-cp -r package.json ./rn-dist/package.json
-cp -r README.md ./rn-dist/README.md
-cp -r LICENSE ./rn-dist/LICENSE
-cp -r CHANGELOG.md ./rn-dist/CHANGELOG.md
+cp -r package.json ./dist/package.json
+cp -r README.md ./dist/README.md
+cp -r LICENSE ./dist/LICENSE
+cp -r CHANGELOG.md ./dist/CHANGELOG.md
 
 echo -e "${GRAY}Complete${NC}\r\n"

--- a/react-native/scripts/linkProgress.sh
+++ b/react-native/scripts/linkProgress.sh
@@ -19,7 +19,7 @@ mkdir -p "./demo/node_modules/@brightlayer-ui/react-native-progress-icons"
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying build output into node_modules...${NC}";
-cp -r ./rn-dist/* ./demo/node_modules/@brightlayer-ui/react-native-progress-icons/
+cp -r ./dist/* ./demo/node_modules/@brightlayer-ui/react-native-progress-icons/
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying package.json into node_modules...${NC}";

--- a/react-native/scripts/testBuild.sh
+++ b/react-native/scripts/testBuild.sh
@@ -7,28 +7,28 @@ NC='\033[0m' # No Color
 echo -n "Checking progress icon build artifacts (React Native)... "
 yarn build
 
-if [ ! -d ./rn-dist ]; then echo -e "${RED}Not Found${NC}" && exit 1; fi
+if [ ! -d ./dist ]; then echo -e "${RED}Not Found${NC}" && exit 1; fi
 echo "Checking for required files..."
 echo -ne "  Battery.js: "
-if [ ! -f ./rn-dist/Battery.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Battery.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Battery.d.ts: "
-if [ ! -f ./rn-dist/Battery.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Battery.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Heart.js: "
-if [ ! -f ./rn-dist/Heart.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Heart.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Heart.d.ts: "
-if [ ! -f ./rn-dist/Heart.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Heart.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Pie.js: "
-if [ ! -f ./rn-dist/Pie.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Pie.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Pie.d.ts: "
-if [ ! -f ./rn-dist/Pie.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Pie.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Ups.js: "
-if [ ! -f ./rn-dist/Ups.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Ups.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Ups.d.ts: "
-if [ ! -f ./rn-dist/Ups.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Ups.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  index.js: "
-if [ ! -f ./rn-dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  index.d.ts: "
-if [ ! -f ./rn-dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  package.json: "
 if [ ! -f ./package.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  README: "

--- a/react-native/tsconfig.lib.json
+++ b/react-native/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "outDir": "./rn-dist",
+        "outDir": "./dist",
         "declaration": true
     },
     "exclude": ["src/**.test.ts", "src/**.test.tsx"]

--- a/react/icons/PUBLISHING.md
+++ b/react/icons/PUBLISHING.md
@@ -2,7 +2,7 @@
 
 ## Automatic Publishing
 
-This package is published to NPM automatically by CircleCI when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `package.json` and merge your code into the appropriate branch.
+This package is published to NPM automatically by Github when code is merged into the `dev` or `master` branches. To publish a new version, simply update the version in `package.json` and merge your code into the appropriate branch.
 - The `dev` branch will publish versions marked as `alpha` or `beta`.
 - The `master` branch will publish any version (`alpha`, `beta`, or `latest`).
   In both cases, the code will only be published if the version number differs from the current version published under the respective dist tag.
@@ -25,4 +25,4 @@ yarn build
 npm adduser && yarn publish:package
 ```
 
-> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in CircleCI.
+> Publishing manually should only be done for `alpha` or `beta` packages. The command will work for `latest` packages, but this should be avoided except in rare situations where the automatic publishing functionality is not working in Github.

--- a/react/icons/tsconfig.json
+++ b/react/icons/tsconfig.json
@@ -8,7 +8,7 @@
         "allowSyntheticDefaultImports": true,
         "strictNullChecks": false,
         "lib": ["esnext", "dom"],
-        "outDir": "react-dist"
+        "outDir": "dist"
     },
     "include": [
         "src"

--- a/scripts/progressBuildTest.sh
+++ b/scripts/progressBuildTest.sh
@@ -7,28 +7,28 @@ NC='\033[0m' # No Color
 echo -n "Checking progress icons (React)... "
 cd ./react/icons
 yarn && yarn build
-if [ ! -d ./react-dist ]; then echo -e "${RED}Not Found${NC}" && exit 1; fi
+if [ ! -d ./dist ]; then echo -e "${RED}Not Found${NC}" && exit 1; fi
 echo "Checking for required files..."
 echo -ne "  Battery.js: "
-if [ ! -f ./react-dist/Battery.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Battery.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Battery.d.ts: "
-if [ ! -f ./react-dist/Battery.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Battery.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Heart.js: "
-if [ ! -f ./react-dist/Heart.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Heart.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Heart.d.ts: "
-if [ ! -f ./react-dist/Heart.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Heart.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Pie.js: "
-if [ ! -f ./react-dist/Pie.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Pie.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Pie.d.ts: "
-if [ ! -f ./react-dist/Pie.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Pie.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Ups.js: "
-if [ ! -f ./react-dist/Ups.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Ups.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  Ups.d.ts: "
-if [ ! -f ./react-dist/Ups.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/Ups.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  index.js: "
-if [ ! -f ./react-dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/index.js ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  index.d.ts: "
-if [ ! -f ./react-dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
+if [ ! -f ./dist/index.d.ts ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  package.json: "
 if [ ! -f ./package.json ]; then echo -e "${RED}Not Found${NC}" && exit 1; else echo -e "${GREEN}Found${NC}"; fi
 echo -ne "  readme: "


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-5602.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- update blui-ci no cache dirs
- revert all changes to dist build folders & update scripts (revert this PR https://github.com/etn-ccis/blui-progress-icons/pull/184)
- update root readme with build badge
- remove circleCI references from publish readme files
- remove circleCI badge from react-native readme

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- uploaded artifact names
![image](https://github.com/etn-ccis/blui-progress-icons/assets/119693939/6fb3244b-1b9c-43f6-85e9-cf51ee7b0678)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- if you want to see jobs run make small commit and revert it or see jobs here
- https://github.com/etn-ccis/blui-progress-icons/actions/runs/8896217923

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
